### PR TITLE
Use self instead of README for stat check

### DIFF
--- a/copy-from-time-machine.sh
+++ b/copy-from-time-machine.sh
@@ -34,7 +34,7 @@ hfsd="$3"
 export LC_ALL=C
 
 # test if "stat" is responding as expected on this machine
-read type <<<$(stat -c '%F' "README.md")
+read type <<<$(stat -c '%F' "$self")
 if [ "$type" != "regular file" ]; then
   echo "There are problems with your language settings. The 'stat' command must answer in English,
 i.e. 'regular file' but it's answer was '$type'.


### PR DESCRIPTION
Currently the script relies on README.md to be in the working directory, otherwise the script fails and incorrectly reports a language error. This is incompatible with the readme which says you can just download the script alone. Instead, this change applies the stat check to the script itself, regardless of the current working directory and without a dependency on README.md.