### PR TITLE
Replace -n with --update=none

### DIFF
--- a/copy-from-time-machine.sh
+++ b/copy-from-time-machine.sh
@@ -82,7 +82,7 @@ find "$source" -mindepth 1 -maxdepth 1 -and -not -name . -and -not -name .. | wh
 
   case $type in
     'regular file'|'symbolic link')
-      cp -van "$entry" "$dest"
+      cp -va --update=none "$entry" "$dest"
       ;;
 
     'directory')


### PR DESCRIPTION
This suppresses non-portable warnings.